### PR TITLE
Updated completed category folders; removed incomplete category folde…

### DIFF
--- a/apps/sabnzbd.yml
+++ b/apps/sabnzbd.yml
@@ -69,10 +69,11 @@
       file: 'path={{item}} state=directory mode=0775 owner=1000 group=1000'
       with_items:
         - '{{path.stdout}}/incomplete/{{pgrole}}'
-        - '{{path.stdout}}/incomplete/{{pgrole}}/tv'
-        - '{{path.stdout}}/incomplete/{{pgrole}}/movies'
-        - '{{path.stdout}}/incomplete/{{pgrole}}/ebooks'
-        - '{{path.stdout}}/incomplete/{{pgrole}}/abooks'
+# These foldes are not used by Sab and create orphaned files warnings. THey are used in the complete path instead.
+#        - '{{path.stdout}}/incomplete/{{pgrole}}/tv'
+#        - '{{path.stdout}}/incomplete/{{pgrole}}/movies'
+#        - '{{path.stdout}}/incomplete/{{pgrole}}/ebooks'
+#        - '{{path.stdout}}/incomplete/{{pgrole}}/abooks'
       when: incomplete.stdout | length == 0
       ignore_errors: yes
 
@@ -130,6 +131,17 @@
         option: complete_dir
         value: '{{path.stdout}}/downloads/{{pgrole}}'
         state: present
+        
+#Sab will place files set in the Categories section into these folders before moving them to the Radarr/Sonarr/Lidarr etc set dirctory
+    - name: Creating complete paths
+      file: 'path={{item}} state=directory mode=0775 owner=1000 group=1000'
+      with_items:
+        - '{{path.stdout}}/downloads/{{pgrole}}/tv'
+        - '{{path.stdout}}/downloads/{{pgrole}}/movies'
+        - '{{path.stdout}}/downloads/{{pgrole}}/ebooks'
+        - '{{path.stdout}}/downloads/{{pgrole}}/abooks'
+        - '{{path.stdout}}/downloads/{{pgrole}}/music'
+      ignore_errors: yes
 
     - name: Set nzb watch location
       ini_file:


### PR DESCRIPTION
-Folders for categories in the "incomplete" path (lines 72-75) cause orphaned file errors in Sab when created.

-Creating these folders in the "complete" path (line 134-143) allow Sab to place completed files in the correct category folders after download is finished. (Categories must be assigned with those folders in the Sab settings to use them.) The various feeder programs (Radarr, Sonarr, Lidarr, etc) will then move the files from those category folders to the proper final locations.

-Note: Use of the category folders (i.e. setting them in the SabNZBD Config/Categories section) is completely optional and doing so or not doing so does not impact the feeder programs from moving them. It does create some organization and consistency however.